### PR TITLE
inline layout align bugfix

### DIFF
--- a/src/sass/bolts.scss
+++ b/src/sass/bolts.scss
@@ -939,7 +939,7 @@ $bolts-selectors:                              false !default;
 		}
 
 		> * {
-			@include inline-column($width, $gutters);
+			@include inline-column($width, $gutters, $align);
 		}
 	}
 }


### PR DESCRIPTION
fixed issue with `inline-column` not inheriting `$align` from `inline-layout`